### PR TITLE
Adds a required_providers block with a minimum version for the aws provider

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@
 .tardigrade-ci
 tardigrade-ci/
 
-# eclint
-.git/
-
 # terratest
 tests/go.*
+
+# terraform lock file
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Note: the implementation `tests/create_guardduty_member` will require you to pro
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
-| aws.master | n/a |
+| aws | >= 3.0 |
+| aws.master | >= 3.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,6 @@ provider "aws" {
 }
 
 resource "aws_guardduty_detector" "this" {
-  provider = aws
-
   enable = true
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,10 @@
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
 }


### PR DESCRIPTION
This helps resolve warnings in tf 0.15 of the form:

```
Module module.<MODULE> does not declare a provider named aws.
If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers block within the module.
```