### PR TITLE
Uses dynamic block for malware protection, to support govcloud

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 3.1.1
+
+**Released**: 2022.08.09
+
+**Commit Delta**: [Change from 3.1.0 release](https://github.com/plus3it/terraform-aws-tardigrade-guardduty/compare/3.1.0...3.1.1)
+
+**Summary**:
+
+*   Uses dynamic block to null the malware protection data source when input is `null`
+
 ### 3.1.0
 
 **Released**: 2022.08.03

--- a/main.tf
+++ b/main.tf
@@ -18,15 +18,21 @@ resource "aws_guardduty_detector" "this" {
     s3_logs {
       enable = var.enable_s3_protection
     }
+
     kubernetes {
       audit_logs {
         enable = var.enable_kubernetes_protection
       }
     }
-    malware_protection {
-      scan_ec2_instance_with_findings {
-        ebs_volumes {
-          enable = var.enable_malware_protection
+
+    dynamic "malware_protection" {
+      for_each = var.enable_malware_protection != null ? ["one"] : []
+
+      content {
+        scan_ec2_instance_with_findings {
+          ebs_volumes {
+            enable = var.enable_malware_protection
+          }
         }
       }
     }

--- a/modules/member/main.tf
+++ b/modules/member/main.tf
@@ -13,15 +13,21 @@ resource "aws_guardduty_detector" "this" {
     s3_logs {
       enable = var.enable_s3_protection
     }
+
     kubernetes {
       audit_logs {
         enable = var.enable_kubernetes_protection
       }
     }
-    malware_protection {
-      scan_ec2_instance_with_findings {
-        ebs_volumes {
-          enable = var.enable_malware_protection
+
+    dynamic "malware_protection" {
+      for_each = var.enable_malware_protection != null ? ["one"] : []
+
+      content {
+        scan_ec2_instance_with_findings {
+          ebs_volumes {
+            enable = var.enable_malware_protection
+          }
         }
       }
     }

--- a/modules/org-admin-account/main.tf
+++ b/modules/org-admin-account/main.tf
@@ -21,15 +21,21 @@ resource "aws_guardduty_organization_configuration" "this" {
     s3_logs {
       auto_enable = var.auto_enable_s3_protection
     }
+
     kubernetes {
       audit_logs {
         enable = var.enable_kubernetes_protection
       }
     }
-    malware_protection {
-      scan_ec2_instance_with_findings {
-        ebs_volumes {
-          auto_enable = var.auto_enable_malware_protection
+
+    dynamic "malware_protection" {
+      for_each = var.auto_enable_malware_protection != null ? ["one"] : []
+
+      content {
+        scan_ec2_instance_with_findings {
+          ebs_volumes {
+            enable = var.auto_enable_malware_protection
+          }
         }
       }
     }


### PR DESCRIPTION
Malware protection is not available in GovCloud:

> [Amazon GuardDuty](https://aws.amazon.com/guardduty/) Malware Protection is available today in [all AWS Regions where GuardDuty is available](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/), excluding the AWS China (Beijing), AWS China (Ningxia), AWS GovCloud (US-East), and AWS GovCloud (US-West) Regions
>
>https://aws.amazon.com/blogs/aws/new-for-amazon-guardduty-malware-detection-for-amazon-ebs-volumes

To stop terraform from making the API call, the datasource for malware protection must not be present at all when the config is processed. To create that effect, we need to use a dynamic block. With this patch, when a user sets malware protection to `null`, the data source will not be part of the processed config, and terraform will not include it in the API call.